### PR TITLE
Defect 94. When fetching user details double check user is granted to…

### DIFF
--- a/src/main/java/com/devicehive/auth/CheckPermissionsHelper.java
+++ b/src/main/java/com/devicehive/auth/CheckPermissionsHelper.java
@@ -31,6 +31,12 @@ public class CheckPermissionsHelper {
                 if (!isCurrentPermissionAllowed) {
                     permissionsToRemove.add(currentPermission);
                 }
+            } else {
+                if (currentPermission.getAccessKey() != null  && currentPermission.getAccessKey().getUser().getRole() != UserRole.ADMIN) {
+                    if (AvailableActions.getAdminActions().contains(allowedAction.getValue())) {
+                        permissionsToRemove.add(currentPermission);
+                    }
+                }
             }
         }
         permissions.removeAll(permissionsToRemove);

--- a/src/test/java/com/devicehive/resource/UserResourceTest.java
+++ b/src/test/java/com/devicehive/resource/UserResourceTest.java
@@ -35,8 +35,10 @@ public class UserResourceTest extends AbstractResourceTest {
         User user = performRequest("/user", "POST", emptyMap(), singletonMap(HttpHeaders.AUTHORIZATION, basicAuthHeader(ADMIN_LOGIN, ADMIN_PASS)), testUser, CREATED, User.class);
         assertThat(user.getId(), notNullValue());
 
+        final long userid = user.getId();
         user = performRequest("/user/" + user.getId(), "GET", emptyMap(), singletonMap(HttpHeaders.AUTHORIZATION, basicAuthHeader(ADMIN_LOGIN, ADMIN_PASS)), null, OK, User.class);
         assertThat(user.getStatus(), equalTo(UserStatus.ACTIVE));
+        assertThat(user.getId(), equalTo(userid));
 
         testUser = new UserUpdate();
         testUser.setStatus(new NullableWrapper<>(UserStatus.DISABLED.getValue()));


### PR DESCRIPTION
… see details of other users.

Protected get user details, while get user list does not require additional protection as it could be accessed only by administrator. Did quick check over the update and update current, both seems to satisfy security settings. The only operation that seems to have strange permission set is @Path("/{id}/network/{networkId}") - @demon-xxi , @SorJEF guys, need your assistance on it.

Probably user authenticated with key, can access networks from the other users.

Fixes for issue #94.