### PR TITLE
#113 disable html escaping when rendering json objects.

### DIFF
--- a/src/main/java/com/devicehive/json/GsonFactory.java
+++ b/src/main/java/com/devicehive/json/GsonFactory.java
@@ -38,6 +38,7 @@ public class GsonFactory {
 
     private static GsonBuilder createGsonBuilder() {
         return new GsonBuilder()
+            .disableHtmlEscaping()
             .setPrettyPrinting()
             .serializeNulls()
             .registerTypeAdapterFactory(new NullableWrapperAdapterFactory())


### PR DESCRIPTION
issue was found in testing session with @Nikolay-Kha 
when DH sends json respond it escapes = with \xxx which causes clients to fail.