### PR TITLE
#118 Added behavior to devices registered by admin.

### DIFF
--- a/src/main/java/com/devicehive/configuration/Messages.java
+++ b/src/main/java/com/devicehive/configuration/Messages.java
@@ -101,6 +101,7 @@ public class Messages {
     public static final String PING_ERROR = BidBundle.get("PING_ERROR");
     public static final String SHUTDOWN = BidBundle.get("SHUTDOWN");
     public static final String NO_ACCESS_TO_DEVICE = BidBundle.get("NO_ACCESS_TO_DEVICE");
+    public static final String NO_NETWORKS_ASSIGNED_TO_USER = BidBundle.get("NO_NETWORKS_ASSIGNED_TO_USER");
 
     /**
      * Bundle to extract localized strings from property files.

--- a/src/main/java/com/devicehive/service/DeviceService.java
+++ b/src/main/java/com/devicehive/service/DeviceService.java
@@ -411,14 +411,12 @@ public class DeviceService {
             HivePrincipal principal = (HivePrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
             User user = findUserFromAuth(principal);
             if (user != null) {
-                if (!user.isAdmin()) {
-                    Set<Network> userNetworks = userService.findUserWithNetworks(user.getId()).getNetworks();
-                    if (userNetworks.isEmpty()) {
-                        throw new HiveException(Messages.NO_ACCESS_TO_NETWORK, PRECONDITION_FAILED.getStatusCode());
-                    }
-
-                    return userNetworks.iterator().next();
+                Set<Network> userNetworks = userService.findUserWithNetworks(user.getId()).getNetworks();
+                if (userNetworks.isEmpty()) {
+                    throw new HiveException(Messages.NO_NETWORKS_ASSIGNED_TO_USER, PRECONDITION_FAILED.getStatusCode());
                 }
+
+                return userNetworks.iterator().next();
             }
         }
         return network;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -90,3 +90,4 @@ FIELD_LENGTH_CONSTRAINT=Field cannot be empty. The length of %s should not be mo
 PING_ERROR=Error sending websocket ping
 SHUTDOWN=Shutdown
 NO_ACCESS_TO_DEVICE=No access to device
+NO_NETWORKS_ASSIGNED_TO_USER=User has no networks assigned to him


### PR DESCRIPTION
If network didn't passed with device then device would be assigned to admin's default network. If admin don't assigned to any network then return response with 412 code.