### PR TITLE
Makes spring boot packaging plugin use PropertiesLauncher in manifest…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,7 @@
                     <version>${springboot.version}</version>
                     <configuration>
                         <classifier>boot</classifier>
+                        <layout>ZIP</layout>
                         <addResources>false</addResources>
                     </configuration>
                     <executions>


### PR DESCRIPTION
… instead of JarLauncher which allow to add externals jar to classpath.
