### PR TITLE
Notification not found fix

### DIFF
--- a/devicehive-common/src/main/java/com/devicehive/configuration/Messages.java
+++ b/devicehive-common/src/main/java/com/devicehive/configuration/Messages.java
@@ -126,6 +126,8 @@ public class Messages {
     public static final String CANT_DELETE_CURRENT_USER_KEY = BidBundle.get("CANT_DELETE_CURRENT_USER_KEY");
     public static final String CANT_DELETE_LAST_DEFAULT_ACCESS_KEY = BidBundle.get("CANT_DELETE_LAST_DEFAULT_ACCESS_KEY");
     public static final String FORBIDDEN_INSERT_USER = BidBundle.get("FORBIDDEN_INSERT_USER");
+    public static final String FORBIDDEN_INSERT_SPECIAL_NOTIFICATION = BidBundle.get("FORBIDDEN_INSERT_SPECIAL_NOTIFICATION");
+    public static final String NOTIFICATION_INSERT_FAILED = BidBundle.get("NOTIFICATION_INSERT_FAILED");
 
     /**
      * Bundle to extract localized strings from property files.

--- a/devicehive-frontend/src/main/resources/messages.properties
+++ b/devicehive-frontend/src/main/resources/messages.properties
@@ -114,3 +114,5 @@ NO_NETWORKS_ASSIGNED_TO_USER=User has no networks assigned to him
 CANT_DELETE_CURRENT_USER_KEY=You can not delete a user or access key that you use to authenticate this request
 CANT_DELETE_LAST_DEFAULT_ACCESS_KEY=You can not delete your last default access key
 FORBIDDEN_INSERT_USER=You should be authorized with role MANAGE_USER or user anonymous creation should be enabled
+FORBIDDEN_INSERT_SPECIAL_NOTIFICATION=It's forbidden to insert these special notifications: $device-update, $device-add.
+NOTIFICATION_INSERT_FAILED=Device notification insert failed for device with guid %s.


### PR DESCRIPTION
Bug Ticket [here](https://trello.com/c/mUSMYgg3/53-bug-admin-devices-notifications-notification-with-id-1-not-found-warning-appears-when-copying-and-pushing-notification).
Notification service excludes special notification (device update) from list and it causes IndexOutOfBounds exception in lambda. I prevented manual adding special notifications.