### PR TITLE
Migrate sortOrder param from Boolean to boolean

### DIFF
--- a/devicehive-common-dao/src/main/java/com/devicehive/dao/DeviceClassDao.java
+++ b/devicehive-common-dao/src/main/java/com/devicehive/dao/DeviceClassDao.java
@@ -38,7 +38,7 @@ public interface DeviceClassDao {
     DeviceClassWithEquipmentVO merge(DeviceClassWithEquipmentVO deviceClass);
 
     List<DeviceClassWithEquipmentVO> list(String name, String namePattern, String sortField,
-                                                Boolean sortOrderAsc, Integer take, Integer skip);
+                                                boolean sortOrderAsc, Integer take, Integer skip);
 
     DeviceClassWithEquipmentVO findByName(@NotNull String name);
 

--- a/devicehive-common-dao/src/main/java/com/devicehive/dao/DeviceDao.java
+++ b/devicehive-common-dao/src/main/java/com/devicehive/dao/DeviceDao.java
@@ -46,7 +46,7 @@ public interface DeviceDao {
     long getAllowedDeviceCount(HivePrincipal principal, List<String> guids);
 
     List<DeviceVO> list(String name, String namePattern, Long networkId, String networkName,
-                         Long deviceClassId, String deviceClassName, String sortField, @NotNull Boolean sortOrderAsc, Integer take,
+                         Long deviceClassId, String deviceClassName, String sortField, boolean sortOrderAsc, Integer take,
                          Integer skip, HivePrincipal principal);
 
 }

--- a/devicehive-common-dao/src/main/java/com/devicehive/dao/UserDao.java
+++ b/devicehive-common-dao/src/main/java/com/devicehive/dao/UserDao.java
@@ -56,5 +56,5 @@ public interface UserDao {
     void unassignNetwork(@NotNull UserVO existingUser, @NotNull long networkId);
 
     List<UserVO> list(String login, String loginPattern, Integer role, Integer status, String sortField,
-                       Boolean sortOrderAsc, Integer take, Integer skip);
+                       boolean sortOrderAsc, Integer take, Integer skip);
 }

--- a/devicehive-common/src/main/java/com/devicehive/model/rpc/ListDeviceClassRequest.java
+++ b/devicehive-common/src/main/java/com/devicehive/model/rpc/ListDeviceClassRequest.java
@@ -27,7 +27,7 @@ public class ListDeviceClassRequest extends Body {
     private String name;
     private String namePattern;
     private String sortField;
-    private Boolean sortOrderAsc;
+    private boolean sortOrderAsc;
     private Integer take;
     private Integer skip;
 
@@ -59,11 +59,11 @@ public class ListDeviceClassRequest extends Body {
         this.sortField = sortField;
     }
 
-    public Boolean getSortOrderAsc() {
+    public boolean getSortOrderAsc() {
         return sortOrderAsc;
     }
 
-    public void setSortOrderAsc(Boolean sortOrderAsc) {
+    public void setSortOrderAsc(boolean sortOrderAsc) {
         this.sortOrderAsc = sortOrderAsc;
     }
 

--- a/devicehive-common/src/main/java/com/devicehive/model/rpc/ListDeviceRequest.java
+++ b/devicehive-common/src/main/java/com/devicehive/model/rpc/ListDeviceRequest.java
@@ -32,7 +32,7 @@ public class ListDeviceRequest extends Body {
     private Long deviceClassId;
     private String deviceClassName;
     private String sortField;
-    private Boolean sortOrderAsc;
+    private boolean sortOrderAsc;
     private Integer take;
     private Integer skip;
     private HivePrincipal principal;
@@ -97,11 +97,11 @@ public class ListDeviceRequest extends Body {
         this.sortField = sortField;
     }
 
-    public Boolean getSortOrderAsc() {
+    public boolean getSortOrderAsc() {
         return sortOrderAsc;
     }
 
-    public void setSortOrderAsc(Boolean sortOrderAsc) {
+    public void setSortOrderAsc(boolean sortOrderAsc) {
         this.sortOrderAsc = sortOrderAsc;
     }
 

--- a/devicehive-common/src/main/java/com/devicehive/model/rpc/ListUserRequest.java
+++ b/devicehive-common/src/main/java/com/devicehive/model/rpc/ListUserRequest.java
@@ -29,7 +29,7 @@ public class ListUserRequest extends Body {
     private Integer role;
     private Integer status;
     private String sortField;
-    private Boolean sortOrderAsc;
+    private boolean sortOrderAsc;
     private Integer take;
     private Integer skip;
 
@@ -77,11 +77,11 @@ public class ListUserRequest extends Body {
         this.sortField = sortField;
     }
 
-    public Boolean getSortOrderAsc() {
+    public boolean getSortOrderAsc() {
         return sortOrderAsc;
     }
 
-    public void setSortOrderAsc(Boolean sortOrderAsc) {
+    public void setSortOrderAsc(boolean sortOrderAsc) {
         this.sortOrderAsc = sortOrderAsc;
     }
 

--- a/devicehive-frontend/src/main/java/com/devicehive/service/DeviceClassService.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/service/DeviceClassService.java
@@ -256,7 +256,7 @@ public class DeviceClassService {
 
     //@Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CompletableFuture<List<DeviceClassWithEquipmentVO>> list(String name, String namePattern, String sortField,
-                                                                   Boolean sortOrderAsc, Integer take, Integer skip) {
+                                                                   boolean sortOrderAsc, Integer take, Integer skip) {
         ListDeviceClassRequest request = new ListDeviceClassRequest();
         request.setName(name);
         request.setNamePattern(namePattern);

--- a/devicehive-frontend/src/main/java/com/devicehive/service/DeviceService.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/service/DeviceService.java
@@ -320,7 +320,7 @@ public class DeviceService {
                                                  Long deviceClassId,
                                                  String deviceClassName,
                                                  String sortField,
-                                                 @NotNull Boolean sortOrderAsc,
+                                                 boolean sortOrderAsc,
                                                  Integer take,
                                                  Integer skip,
                                                  HivePrincipal principal) {

--- a/devicehive-frontend/src/main/java/com/devicehive/service/UserService.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/service/UserService.java
@@ -264,7 +264,7 @@ public class UserService {
 
     //@Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CompletableFuture<List<UserVO>> list(String login, String loginPattern, Integer role, Integer status, String sortField,
-                                                  Boolean sortOrderAsc, Integer take, Integer skip) {
+                                                  boolean sortOrderAsc, Integer take, Integer skip) {
         ListUserRequest request = new ListUserRequest();
         request.setLogin(login);
         request.setLoginPattern(loginPattern);

--- a/devicehive-frontend/src/test/java/com/devicehive/service/UserServiceTest.java
+++ b/devicehive-frontend/src/test/java/com/devicehive/service/UserServiceTest.java
@@ -1221,7 +1221,7 @@ public class UserServiceTest extends AbstractResourceTest {
         testUser = userService.createUser(testUser, RandomStringUtils.randomAlphabetic(10));
         handleListUserRequest();
         final UserVO finalTestUser = testUser;
-        userService.list(testUser.getLogin(), null, null, null, null, null, 100, 0)
+        userService.list(testUser.getLogin(), null, null, null, null, false, 100, 0)
                 .thenAccept(users -> {
                     assertThat(users, not(empty()));
                     assertThat(users, hasSize(1));
@@ -1247,7 +1247,7 @@ public class UserServiceTest extends AbstractResourceTest {
             userService.createUser(user, RandomStringUtils.randomAlphabetic(10));
         }
         handleListUserRequest();
-        userService.list(null, "%" + prefix + "%", null, null, null, null, 100, 0)
+        userService.list(null, "%" + prefix + "%", null, null, null, false, 100, 0)
                 .thenAccept(users -> {
                     assertThat(users, not(empty()));
                     assertThat(users, hasSize(5));
@@ -1278,7 +1278,7 @@ public class UserServiceTest extends AbstractResourceTest {
             userService.createUser(user, RandomStringUtils.randomAlphabetic(10));
         }
         handleListUserRequest();
-        userService.list(null, "%" + prefix + "%", UserRole.CLIENT.getValue(), null, null, null, 100, 0)
+        userService.list(null, "%" + prefix + "%", UserRole.CLIENT.getValue(), null, null, false, 100, 0)
                 .thenAccept(users -> {
                     assertThat(users, not(empty()));
                     assertThat(users, hasSize(10));
@@ -1308,7 +1308,7 @@ public class UserServiceTest extends AbstractResourceTest {
             userService.createUser(user, RandomStringUtils.randomAlphabetic(10));
         }
         handleListUserRequest();
-        userService.list(null, "%" + prefix + "%", null, UserStatus.LOCKED_OUT.getValue(), null, null, 100, 0)
+        userService.list(null, "%" + prefix + "%", null, UserStatus.LOCKED_OUT.getValue(), null, false, 100, 0)
                 .thenAccept(users -> {
                     assertThat(users, not(empty()));
                     assertThat(users, hasSize(10));

--- a/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceClassDaoRdbmsImpl.java
+++ b/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceClassDaoRdbmsImpl.java
@@ -93,7 +93,7 @@ public class DeviceClassDaoRdbmsImpl extends RdbmsGenericDao implements DeviceCl
     }
 
     @Override
-    public List<DeviceClassWithEquipmentVO> list(String name, String namePattern, String sortField, Boolean sortOrderAsc, Integer take, Integer skip) {
+    public List<DeviceClassWithEquipmentVO> list(String name, String namePattern, String sortField, boolean sortOrderAsc, Integer take, Integer skip) {
         final CriteriaBuilder cb = criteriaBuilder();
         final CriteriaQuery<DeviceClass> criteria = cb.createQuery(DeviceClass.class);
         final Root<DeviceClass> from = criteria.from(DeviceClass.class);

--- a/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceDaoRdbmsImpl.java
+++ b/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceDaoRdbmsImpl.java
@@ -155,7 +155,7 @@ public class DeviceDaoRdbmsImpl extends RdbmsGenericDao implements DeviceDao {
 
     @Override
     public List<DeviceVO> list(String name, String namePattern, Long networkId, String networkName,
-                                Long deviceClassId, String deviceClassName, String sortField, @NotNull boolean sortOrderAsc, Integer take,
+                                Long deviceClassId, String deviceClassName, String sortField, boolean sortOrderAsc, Integer take,
                                 Integer skip, HivePrincipal principal) {
         final CriteriaBuilder cb = criteriaBuilder();
         final CriteriaQuery<Device> criteria = cb.createQuery(Device.class);

--- a/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceDaoRdbmsImpl.java
+++ b/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/DeviceDaoRdbmsImpl.java
@@ -155,7 +155,7 @@ public class DeviceDaoRdbmsImpl extends RdbmsGenericDao implements DeviceDao {
 
     @Override
     public List<DeviceVO> list(String name, String namePattern, Long networkId, String networkName,
-                                Long deviceClassId, String deviceClassName, String sortField, @NotNull Boolean sortOrderAsc, Integer take,
+                                Long deviceClassId, String deviceClassName, String sortField, @NotNull boolean sortOrderAsc, Integer take,
                                 Integer skip, HivePrincipal principal) {
         final CriteriaBuilder cb = criteriaBuilder();
         final CriteriaQuery<Device> criteria = cb.createQuery(Device.class);

--- a/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/UserDaoRdbmsImpl.java
+++ b/devicehive-rdbms-dao/src/main/java/com/devicehive/dao/rdbms/UserDaoRdbmsImpl.java
@@ -175,7 +175,7 @@ public class UserDaoRdbmsImpl extends RdbmsGenericDao implements UserDao {
     @Override
     public List<UserVO> list(String login, String loginPattern,
                               Integer role, Integer status,
-                              String sortField, Boolean sortOrderAsc,
+                              String sortField, boolean sortOrderAsc,
                               Integer take, Integer skip) {
         CriteriaBuilder cb = criteriaBuilder();
         CriteriaQuery<User> cq = cb.createQuery(User.class);

--- a/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/DeviceClassDaoRiakImpl.java
+++ b/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/DeviceClassDaoRiakImpl.java
@@ -112,7 +112,7 @@ public class DeviceClassDaoRiakImpl extends RiakGenericDao implements DeviceClas
 
     @Override
     public List<DeviceClassWithEquipmentVO> list(String name, String namePattern, String sortField,
-            Boolean isSortOrderAsc, Integer take, Integer skip) {
+            boolean isSortOrderAsc, Integer take, Integer skip) {
         BucketMapReduce.Builder builder = new BucketMapReduce.Builder()
                 .withNamespace(DEVICE_CLASS_NS);
         addMapValues(builder);

--- a/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/DeviceDaoRiakImpl.java
+++ b/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/DeviceDaoRiakImpl.java
@@ -202,7 +202,7 @@ public class DeviceDaoRiakImpl extends RiakGenericDao implements DeviceDao {
     @Override
     public List<DeviceVO> list(String name, String namePattern, Long networkId, String networkName,
             Long deviceClassId, String deviceClassName, String sortField,
-            Boolean isSortOrderAsc, Integer take,
+            boolean isSortOrderAsc, Integer take,
             Integer skip, HivePrincipal principal) {
         //TODO [rafa] when filtering by device class name we have to instead query DeviceClass bucket for ids, and then use ids.
         // here is what happens, since device class is not embeddable in case of Riak we need to either keep id only and perform the logic above.

--- a/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/RiakGenericDao.java
+++ b/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/RiakGenericDao.java
@@ -154,13 +154,8 @@ public class RiakGenericDao {
         return addReduceSort(builder, false, sortField, order);
     }
 
-    protected BucketMapReduce.Builder addReduceSort(BucketMapReduce.Builder builder, Boolean keep, String sortField, Boolean isSortOrderAsc) {
-        SortOrder sortOrder;
-        if (isSortOrderAsc == null) {
-            sortOrder = SortOrder.ASC;
-        } else {
-            sortOrder = (isSortOrderAsc) ? SortOrder.ASC : SortOrder.DESC;
-        }
+    protected BucketMapReduce.Builder addReduceSort(BucketMapReduce.Builder builder, Boolean keep, String sortField, boolean isSortOrderAsc) {
+        SortOrder sortOrder = (isSortOrderAsc) ? SortOrder.ASC : SortOrder.DESC;
         if ((sortField == null) || (sortField.isEmpty())) {
             return addReduceSort(builder, keep, "id", sortOrder);
         } else {
@@ -168,7 +163,7 @@ public class RiakGenericDao {
         }
     }
 
-    protected BucketMapReduce.Builder addReduceSort(BucketMapReduce.Builder builder, String sortField, Boolean isSortOrderAsc) {
+    protected BucketMapReduce.Builder addReduceSort(BucketMapReduce.Builder builder, String sortField, boolean isSortOrderAsc) {
         return addReduceSort(builder, false, sortField, isSortOrderAsc);
     }
 

--- a/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/UserDaoRiakImpl.java
+++ b/devicehive-riak-dao/src/main/java/com/devicehive/dao/riak/UserDaoRiakImpl.java
@@ -239,7 +239,7 @@ public class UserDaoRiakImpl extends RiakGenericDao implements UserDao {
     @Override
     public List<UserVO> list(String login, String loginPattern,
             Integer role, Integer status,
-            String sortField, Boolean isSortOrderAsc,
+            String sortField, boolean isSortOrderAsc,
             Integer take, Integer skip) {
 
         BucketMapReduce.Builder builder = new BucketMapReduce.Builder()


### PR DESCRIPTION
The getList method in several DAOs currently accepts a Boolean sortOrder
parameter. Because of this, riak DAO implementations have to check for
null.
The migration to boolean will involve changing the method signature, and
changing any method calls which pass null.