### PR TITLE
JWT: Store 'jwt.secret' in sysenv, not application.properties

### DIFF
--- a/devicehive-frontend/src/main/java/com/devicehive/security/util/JwtSecretHolder.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/security/util/JwtSecretHolder.java
@@ -1,0 +1,21 @@
+package com.devicehive.security.util;
+
+import java.util.UUID;
+
+public class JwtSecretHolder {
+
+    private String secret = System.getenv("jwt_secret");
+
+    public static final JwtSecretHolder INSTANCE = new JwtSecretHolder();
+
+    private JwtSecretHolder() {
+        if (secret == null) {
+            secret = UUID.randomUUID().toString();
+        }
+    }
+
+    public String getJwtSecret() {
+        return secret;
+    }
+
+}

--- a/devicehive-frontend/src/main/java/com/devicehive/security/util/JwtTokenGenerator.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/security/util/JwtTokenGenerator.java
@@ -38,9 +38,6 @@ import java.util.Map;
 @Component
 public class JwtTokenGenerator {
 
-    @Value("${jwt.secret}")
-    String secret;
-
     @Value("${jwt.refresh-token-max-age}")
     long refreshTokenMaxAge;
 
@@ -68,7 +65,7 @@ public class JwtTokenGenerator {
         Claims claims = Jwts.claims(jwtMap);
         return Jwts.builder()
                 .setClaims(claims)
-                .signWith(SignatureAlgorithm.HS256, secret)
+                .signWith(SignatureAlgorithm.HS256, JwtSecretHolder.INSTANCE.getJwtSecret())
                 .compact();
     }
 }

--- a/devicehive-frontend/src/main/java/com/devicehive/service/security/jwt/JwtClientService.java
+++ b/devicehive-frontend/src/main/java/com/devicehive/service/security/jwt/JwtClientService.java
@@ -22,12 +22,12 @@ package com.devicehive.service.security.jwt;
 
 import com.devicehive.security.jwt.JwtPayload;
 import com.devicehive.security.jwt.TokenType;
+import com.devicehive.security.util.JwtSecretHolder;
 import com.devicehive.security.util.JwtTokenGenerator;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -37,9 +37,6 @@ import java.util.*;
  */
 @Component
 public class JwtClientService {
-
-    @Value("${jwt.secret}")
-    String secret;
 
     @Autowired
     private JwtTokenGenerator tokenGenerator;
@@ -54,7 +51,7 @@ public class JwtClientService {
 
     public JwtPayload getPayload(String jwtToken) {
         Claims claims = Jwts.parser()
-                .setSigningKey(secret)
+                .setSigningKey(JwtSecretHolder.INSTANCE.getJwtSecret())
                 .parseClaimsJws(jwtToken)
                 .getBody();
         LinkedHashMap payloadMap = (LinkedHashMap) claims.get(JwtPayload.JWT_CLAIM_KEY);

--- a/devicehive-frontend/src/main/resources/application.properties
+++ b/devicehive-frontend/src/main/resources/application.properties
@@ -50,8 +50,6 @@ management.security.enabled=true
 management.security.role=ADMIN
 management.security.sessions=STATELESS
 
-#jwt
-jwt.secret=devicehive
 # a half of year age in ms
 jwt.refresh-token-max-age=15724800000
 jwt.access-token-max-age=15724800000

--- a/devicehive-frontend/src/test/java/com/devicehive/resource/JwtTokenResourceTest.java
+++ b/devicehive-frontend/src/test/java/com/devicehive/resource/JwtTokenResourceTest.java
@@ -25,7 +25,7 @@ import com.devicehive.model.enums.UserRole;
 import com.devicehive.model.enums.UserStatus;
 import com.devicehive.security.jwt.JwtPayload;
 import com.devicehive.security.jwt.TokenType;
-import com.devicehive.service.UserService;
+import com.devicehive.security.util.JwtSecretHolder;
 import com.devicehive.service.security.jwt.JwtClientService;
 import com.devicehive.vo.JwtTokenVO;
 import com.devicehive.vo.UserVO;
@@ -35,7 +35,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.annotation.DirtiesContext;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -51,15 +50,6 @@ public class JwtTokenResourceTest extends AbstractResourceTest {
 
     @Autowired
     private JwtClientService jwtClientService;
-
-    @Autowired
-    private JwtClientService tokenService;
-
-    @Autowired
-    private UserService userService;
-
-    @Value("${jwt.secret}")
-    String secret;
 
     @Test
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
@@ -136,7 +126,7 @@ public class JwtTokenResourceTest extends AbstractResourceTest {
         JwtPayload payload = builder.withPublicClaims(userId, actions, networkIds, deviceGuids).buildPayload();
 
         JwtTokenVO token = new JwtTokenVO();
-        String refreshToken = tokenService.generateJwtAccessToken(payload);
+        String refreshToken = jwtClientService.generateJwtAccessToken(payload);
         token.setRefreshToken(refreshToken);
 
         JwtTokenVO jwtToken = performRequest("/token/refresh", "POST", emptyMap(), emptyMap(), token, UNAUTHORIZED, JwtTokenVO.class);
@@ -206,7 +196,7 @@ public class JwtTokenResourceTest extends AbstractResourceTest {
         Claims claims = Jwts.claims(jwtMap);
         String refreshToken = Jwts.builder()
                 .setClaims(claims)
-                .signWith(SignatureAlgorithm.HS256, secret)
+                .signWith(SignatureAlgorithm.HS256, JwtSecretHolder.INSTANCE.getJwtSecret())
                 .compact();
 
         JwtTokenVO tokenVO = new JwtTokenVO();

--- a/devicehive-frontend/src/test/java/com/devicehive/service/JwtClientServiceTest.java
+++ b/devicehive-frontend/src/test/java/com/devicehive/service/JwtClientServiceTest.java
@@ -23,6 +23,7 @@ package com.devicehive.service;
 import com.devicehive.base.AbstractResourceTest;
 import com.devicehive.security.jwt.JwtPayload;
 import com.devicehive.security.jwt.TokenType;
+import com.devicehive.security.util.JwtSecretHolder;
 import com.devicehive.service.security.jwt.JwtClientService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -33,7 +34,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,9 +47,6 @@ public class JwtClientServiceTest  extends AbstractResourceTest {
     @Autowired
     private JwtClientService jwtClientService;
             
-    @Value("${jwt.secret}")
-    private String secret;
-
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 
@@ -110,7 +107,7 @@ public class JwtClientServiceTest  extends AbstractResourceTest {
         Claims claims = Jwts.claims(jwtMap);
         String malformedToken = Jwts.builder()
                 .setClaims(claims)
-                .signWith(SignatureAlgorithm.HS256, secret)
+                .signWith(SignatureAlgorithm.HS256, JwtSecretHolder.INSTANCE.getJwtSecret())
                 .compact();
         jwtClientService.getPayload(malformedToken);
     }


### PR DESCRIPTION
In case the variable for 'jwt.secret' is not set (or empty string) in
environment then generate long random string.

Will have to cases: 1. User doesn't set secret at startup, but still has
secure tokens in his environment. These tokens are not persistent across
application restarts.
2. User sets secret and has tokens persistent across application
restarts.