### PR TITLE
Tweak netcat in container init-scripts

### DIFF
--- a/dockerfiles/devicehive-backend-rdbms/devicehive-start.sh
+++ b/dockerfiles/devicehive-backend-rdbms/devicehive-start.sh
@@ -4,11 +4,11 @@ set -x
 
 # Check if Zookeper, Kafka and Postgres are ready
 while true; do
-    `nc $DH_ZK_ADDRESS $DH_ZK_PORT`
+    `nc -N $DH_ZK_ADDRESS $DH_ZK_PORT`
     result_zk=$?
-    `nc $DH_POSTGRES_ADDRESS $DH_POSTGRES_PORT`
+    `nc -N $DH_POSTGRES_ADDRESS $DH_POSTGRES_PORT`
     result_postgres=$?
-    `nc $DH_KAFKA_ADDRESS $DH_KAFKA_PORT`
+    `nc -N $DH_KAFKA_ADDRESS $DH_KAFKA_PORT`
     result_kafka=$?
 
     if [ "$result_kafka" -eq 0 ] && [ "$result_postgres" -eq 0 ] && [ "$result_zk" -eq 0 ]; then

--- a/dockerfiles/devicehive-backend-riak/devicehive-start.sh
+++ b/dockerfiles/devicehive-backend-riak/devicehive-start.sh
@@ -4,9 +4,9 @@ set -x
 
 # Check if Zookeper, Kafka and riak are ready
 while true; do
-    `nc $DH_ZK_ADDRESS $DH_ZK_PORT`
+    `nc -N $DH_ZK_ADDRESS $DH_ZK_PORT`
     result_zk=$?
-    `nc $DH_KAFKA_ADDRESS $DH_KAFKA_PORT`
+    `nc -N $DH_KAFKA_ADDRESS $DH_KAFKA_PORT`
     result_kafka=$?
     `curl --output /dev/null --silent --head --fail "http://${DH_RIAK_HOST_MEMBER}:${DH_RIAK_HTTP_PORT}/ping"`
     result_riak=$?

--- a/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
+++ b/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
@@ -4,7 +4,7 @@ set -x
 
 # Check if backend is ready
 while true; do
-    `nc $DH_BACKEND_ADDRESS $DH_BACKEND_HAZELCAST_PORT`
+    `nc -N $DH_BACKEND_ADDRESS $DH_BACKEND_HAZELCAST_PORT`
     result=$?
 
     if [ "$result" -eq 0 ]; then

--- a/dockerfiles/devicehive-frontend-riak/devicehive-start.sh
+++ b/dockerfiles/devicehive-frontend-riak/devicehive-start.sh
@@ -4,7 +4,7 @@ set -x
 
 # Check if backend is ready
 while true; do
-    `nc $DH_BACKEND_ADDRESS $DH_BACKEND_HAZELCAST_PORT`
+    `nc -N $DH_BACKEND_ADDRESS $DH_BACKEND_HAZELCAST_PORT`
     result=$?
 
     if [ "$result" -eq 0 ]; then


### PR DESCRIPTION
A 4 years old change in OpenBSD netcat finaly got into Alpine Linux 3.6,
and broke our start scripts.
http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/nc/netcat.c?rev=1.111&content-type=text/x-cvsweb-markup
Add "shutdown(2) the network socket after EOF on the input" parameter.