### PR TITLE
[Docker] Replace 'exec' with signal trapping logic

### DIFF
--- a/dockerfiles/devicehive-backend-rdbms/devicehive-start.sh
+++ b/dockerfiles/devicehive-backend-rdbms/devicehive-start.sh
@@ -2,6 +2,14 @@
 
 set -x
 
+trap 'terminate' TERM INT
+
+terminate() {
+   echo "SIGTERM received, terminating $PID"
+   kill -TERM $PID
+   wait $PID
+}
+
 # Check if all required parameters are set
 if [ -z "$DH_ZK_ADDRESS" \
   -o -z "$DH_KAFKA_ADDRESS" \
@@ -44,7 +52,7 @@ while true; do
 done
 
 echo "Starting DeviceHive backend"
-exec java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+ScavengeBeforeFullGC -XX:+CMSScavengeBeforeRemark -jar \
+java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+ScavengeBeforeFullGC -XX:+CMSScavengeBeforeRemark -jar \
 -Dspring.datasource.url=jdbc:postgresql://${DH_POSTGRES_ADDRESS}:${DH_POSTGRES_PORT}/${DH_POSTGRES_DB} \
 -Dspring.datasource.username="${DH_POSTGRES_USERNAME}" \
 -Dspring.datasource.password="${DH_POSTGRES_PASSWORD}" \
@@ -56,4 +64,6 @@ exec java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMS
 -Drpc.server.request-consumer.threads=${DH_RPC_SERVER_REQ_CONS_THREADS:-1} \
 -Drpc.server.worker.threads=${DH_RPC_SERVER_WORKER_THREADS:-1} \
 -Drpc.server.disruptor.wait-strategy=${DH_RPC_SERVER_DISR_WAIT_STRATEGY:-blocking} \
-./devicehive-backend-${DH_VERSION}-boot.jar
+./devicehive-backend-${DH_VERSION}-boot.jar &
+PID=$!
+wait $PID

--- a/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
+++ b/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
@@ -2,6 +2,14 @@
 
 set -x
 
+trap 'terminate' TERM INT
+
+terminate() {
+   echo "SIGTERM received, terminating $PID"
+   kill -TERM $PID
+   wait $PID
+}
+
 # Check if all required parameters are set
 if [ -z "$DH_ZK_ADDRESS" \
   -o -z "$DH_KAFKA_ADDRESS" \
@@ -22,7 +30,7 @@ then
 fi
 
 echo "Starting DeviceHive frontend"
-exec java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+ScavengeBeforeFullGC -XX:+CMSScavengeBeforeRemark -jar \
+java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -XX:+ScavengeBeforeFullGC -XX:+CMSScavengeBeforeRemark -jar \
 -Dspring.datasource.url=jdbc:postgresql://${DH_POSTGRES_ADDRESS}:${DH_POSTGRES_PORT:-5432}/${DH_POSTGRES_DB} \
 -Dspring.datasource.username="${DH_POSTGRES_USERNAME}" \
 -Dspring.datasource.password="${DH_POSTGRES_PASSWORD}" \
@@ -31,4 +39,6 @@ exec java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMS
 -Drpc.client.response-consumer.threads=${DH_RPC_CLIENT_RES_CONS_THREADS:-1} \
 -Dserver.context-path=/api \
 -Dserver.port=8080 \
-./devicehive-frontend-${DH_VERSION}-boot.jar
+./devicehive-frontend-${DH_VERSION}-boot.jar &
+PID=$!
+wait $PID

--- a/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
+++ b/dockerfiles/devicehive-frontend-rdbms/devicehive-start.sh
@@ -19,7 +19,7 @@ if [ -z "$DH_ZK_ADDRESS" \
   -o -z "$DH_POSTGRES_DB" ]
 then
     echo "Some of required environment variables are not set or empty."
-    echo "Please check following vars are passwed to container:"
+    echo "Please check following vars are passed to container:"
     echo "- DH_ZK_ADDRESS"
     echo "- DH_KAFKA_ADDRESS"
     echo "- DH_POSTGRES_ADDRESS"

--- a/dockerfiles/devicehive-frontend-riak/devicehive-start.sh
+++ b/dockerfiles/devicehive-frontend-riak/devicehive-start.sh
@@ -2,6 +2,14 @@
 
 set -x
 
+trap 'terminate' TERM INT
+
+terminate() {
+   echo "SIGTERM received, terminating $PID"
+   kill -TERM $PID
+   wait $PID
+}
+
 # Check if all required parameters are set
 if [ -z "$DH_ZK_ADDRESS" \
   -o -z "$DH_KAFKA_ADDRESS" \
@@ -27,4 +35,6 @@ exec java -server -Xmx512m -XX:MaxRAMFraction=1 -XX:+UseConcMarkSweepGC -XX:+CMS
 -Drpc.client.response-consumer.threads=${DH_RPC_CLIENT_RES_CONS_THREADS:-1} \
 -Dserver.context-path=/api \
 -Dserver.port=8080 \
-./devicehive-frontend-${DH_VERSION}-boot.jar
+./devicehive-frontend-${DH_VERSION}-boot.jar &
+PID=$!
+wait $PID


### PR DESCRIPTION
When java is run as pid 1 openjdk various utilities fail with
"1: Unable to get pid of LinuxThreads manager thread" message.
This will allow us to take heap dumps with jmap.