### PR TITLE
jenkins: Fixate mocha version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ if (publishable_branches.contains(env.BRANCH_NAME)) {
 
           echo("Install dependencies with npm")
           sh '''
-            sudo npm install -g mocha mochawesome
+            sudo npm install -g mocha@3.5.3 mochawesome
             sudo npm i
           '''
 


### PR DESCRIPTION
Latest mocha release 4.0.1 hangs after tests are ended and waits
endesly for smth. Let's use version 3.5.3 until we find real cause of
an issue.