### PR TITLE
Fix: No message is written to log when user becomes locked out;

### DIFF
--- a/devicehive-common-auth/src/main/java/com/devicehive/service/BaseUserService.java
+++ b/devicehive-common-auth/src/main/java/com/devicehive/service/BaseUserService.java
@@ -141,7 +141,7 @@ public class BaseUserService {
             if (user.getLoginAttempts()
                     >= configurationService.getInt(Constants.MAX_LOGIN_ATTEMPTS, Constants.MAX_LOGIN_ATTEMPTS_DEFAULT)) {
                 user.setStatus(UserStatus.LOCKED_OUT);
-                logger.info("User with id {} has been locked out after {} login attempts.", user.getId(), user.getLoginAttempts());
+                logger.info("User with login {} has been locked out after {} login attempts.", user.getLogin(), user.getLoginAttempts());
                 user.setLoginAttempts(0);
             }
             userDao.merge(user);

--- a/devicehive-common-auth/src/main/java/com/devicehive/service/BaseUserService.java
+++ b/devicehive-common-auth/src/main/java/com/devicehive/service/BaseUserService.java
@@ -141,6 +141,7 @@ public class BaseUserService {
             if (user.getLoginAttempts()
                     >= configurationService.getInt(Constants.MAX_LOGIN_ATTEMPTS, Constants.MAX_LOGIN_ATTEMPTS_DEFAULT)) {
                 user.setStatus(UserStatus.LOCKED_OUT);
+                logger.info("User with id {} has been locked out after {} login attempts.", user.getId(), user.getLoginAttempts());
                 user.setLoginAttempts(0);
             }
             userDao.merge(user);


### PR DESCRIPTION
https://support.dataart.com/browse/DEV-349;
Proper logging for the given scenario was added.