### PR TITLE
docker: update base images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def test_rpc = true
 stage('Build jars') {
   node('docker') {
     echo 'Building jars ...'
-    def maven = docker.image('maven:3.5.2-jdk-8')
+    def maven = docker.image('maven:3.5.3-jdk-8')
     maven.pull()
     maven.inside {
       checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ stage('Build and publish Docker images in CI repository') {
     def plugin = docker.build('devicehiveci/devicehive-plugin:${BRANCH_NAME}', '-f dockerfiles/devicehive-plugin.Dockerfile .')
     def frontend = docker.build('devicehiveci/devicehive-frontend:${BRANCH_NAME}', '-f dockerfiles/devicehive-frontend.Dockerfile .')
     def backend = docker.build('devicehiveci/devicehive-backend:${BRANCH_NAME}', '-f dockerfiles/devicehive-backend.Dockerfile .')
-    def hazelcast = docker.build('devicehiveci/devicehive-hazelcast:${BRANCH_NAME}', '-f dockerfiles/devicehive-hazelcast.Dockerfile .')
+    def hazelcast = docker.build('devicehiveci/devicehive-hazelcast:${BRANCH_NAME}', '--pull -f dockerfiles/devicehive-hazelcast.Dockerfile .')
 
     echo 'Pushing images to CI repository ...'
     docker.withRegistry('https://registry.hub.docker.com', 'devicehiveci_dockerhub'){

--- a/dockerfiles/devicehive-auth.Dockerfile
+++ b/dockerfiles/devicehive-auth.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-slim
+FROM openjdk:8u162-jre-slim
 
 MAINTAINER devicehive
 

--- a/dockerfiles/devicehive-backend.Dockerfile
+++ b/dockerfiles/devicehive-backend.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-slim
+FROM openjdk:8u162-jre-slim
 
 MAINTAINER devicehive
 

--- a/dockerfiles/devicehive-frontend.Dockerfile
+++ b/dockerfiles/devicehive-frontend.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-slim
+FROM openjdk:8u162-jre-slim
 
 MAINTAINER devicehive
 

--- a/dockerfiles/devicehive-hazelcast.Dockerfile
+++ b/dockerfiles/devicehive-hazelcast.Dockerfile
@@ -1,4 +1,4 @@
-FROM hazelcast/hazelcast:3.8.8
+FROM hazelcast/hazelcast:3.8.9
 
 MAINTAINER devicehive
 

--- a/dockerfiles/devicehive-plugin.Dockerfile
+++ b/dockerfiles/devicehive-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre-slim
+FROM openjdk:8u162-jre-slim
 
 MAINTAINER devicehive
 


### PR DESCRIPTION
Use following base images:
* openjdk:8u162-jre-slim
* hazelcast/hazelcast:3.8.9

Maven image, used in Jenkins, updated to maven:3.5.3-jdk-8