### PR TITLE
Add a link to the project architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Project Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/devicehivedevicehivejavaserver/)
 
 DeviceHive Java server
 ======================


### PR DESCRIPTION
Adding a link to the high-level project documentation. Provides list of modules, libraries, module dependency diagram and other high-level information intended to simplify new developer's introduction to the project.